### PR TITLE
feat: adding getter for the choices in a ChoiceTrace (CORE-4947)

### DIFF
--- a/lib/App/types.ts
+++ b/lib/App/types.ts
@@ -1,5 +1,5 @@
 import { State } from "@voiceflow/runtime";
-import { GeneralTrace } from "@voiceflow/general-types";
+import { ChoiceTrace, GeneralTrace } from "@voiceflow/general-types";
 import { DeepReadonly } from "@/lib/Typings";
 
 export type AppConfig = {
@@ -14,3 +14,5 @@ export type InternalAppState = {
 export type AppState = DeepReadonly<InternalAppState & {
     end: boolean;
 }>;
+
+export type Choice = ChoiceTrace['payload']['choices'][number];

--- a/tests/lib/App/app.unit.ts
+++ b/tests/lib/App/app.unit.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import baseAxios from 'axios';
 import App from '@/lib/App';
 import _ from 'lodash';
-import { CHOICE_TRACE, EXPOSED_VF_APP_NEXT_STATE_1, EXPOSED_VF_APP_NEXT_STATE_2, GENERAL_RUNTIME_ENDPOINT_URL, SEND_TEXT_REQUEST_BODY, SEND_TEXT_RESPONSE_BODY, START_REQUEST_BODY, START_RESPONSE_BODY, START_RESPONSE_BODY_WITH_NO_CHOICES, USER_RESPONSE, VERSION_ID, VF_APP_INITIAL_STATE } from './fixtures';
+import { CHOICES_1, CHOICES_2, CHOICES_3, CHOICE_TRACE, EXPOSED_VF_APP_NEXT_STATE_1, EXPOSED_VF_APP_NEXT_STATE_2, GENERAL_RUNTIME_ENDPOINT_URL, SEND_TEXT_REQUEST_BODY, SEND_TEXT_RESPONSE_BODY, START_REQUEST_BODY, START_RESPONSE_BODY, START_RESPONSE_BODY_WITH_MULTIPLE_CHOICES, START_RESPONSE_BODY_WITH_NO_CHOICES, USER_RESPONSE, VERSION_ID, VF_APP_INITIAL_STATE } from './fixtures';
 
 chai.use(chaiAsPromise);
 
@@ -187,5 +187,22 @@ describe('App', () => {
         const chips = VFApp.chips;
 
         expect(chips).to.eql([]);
+    });
+
+    it('get chips, handles data with multiple choice blocks', async () => {
+        const { VFApp, axiosInstance } = createVFApp();
+
+        axiosInstance.get.resolves(asHttpResponse(VF_APP_INITIAL_STATE));
+        axiosInstance.post.resolves(asHttpResponse(START_RESPONSE_BODY_WITH_MULTIPLE_CHOICES));
+
+        await VFApp.start();
+
+        const chips = VFApp.chips;
+
+        expect(chips).to.eql([
+            ...CHOICES_1,
+            ...CHOICES_2,
+            ...CHOICES_3
+        ]);
     });
 });

--- a/tests/lib/App/fixtures.ts
+++ b/tests/lib/App/fixtures.ts
@@ -181,3 +181,50 @@ export const EXPOSED_VF_APP_NEXT_STATE_2: AppState = {
     trace: [ SPEAK_TRACE ],
     end: true,
 };
+
+export const CHOICES_1 = [            
+    { name: 'Do you have small available?' },
+    { name: "I'd like to order a large please" },
+    { name: "I'd like the small  thank you very much" }
+];
+
+export const CHOICES_2 = [            
+    { name: 'Do you have large available?' },
+    { name: "Is there any options for vegans?" },
+    { name: "Is there any options for halal?" }
+];
+
+export const CHOICES_3 = [            
+    { name: 'Do you have handicapped parking?' },
+];
+
+export const START_RESPONSE_BODY_WITH_MULTIPLE_CHOICES: InteractResponse = {
+    state: VF_APP_NEXT_STATE_1,
+    request: null,
+    trace: [
+        FLOW_TRACE,
+        {
+            type: TraceType.CHOICE,
+            payload: {
+                choices: CHOICES_1
+            }
+        }, 
+        STREAM_TRACE,
+        DEBUG_TRACE,
+        {
+            type: TraceType.CHOICE,
+            payload: {
+                choices: CHOICES_2,
+            }
+        }, 
+        SPEAK_TRACE,
+        BLOCK_TRACE,
+        {
+            type: TraceType.CHOICE,
+            payload: {
+                choices: CHOICES_3
+            }
+        },
+        END_TRACE
+    ]
+};


### PR DESCRIPTION
## Description
Adds a `get`ter that retrieves the suggestion chips in the response body from the `general-runtime` endpoint.