### PR TITLE
feat: added traceProcessor dataConfig option (CORE-5112)

### DIFF
--- a/lib/App/index.ts
+++ b/lib/App/index.ts
@@ -69,7 +69,13 @@ class App<S extends Record<string, any> = Record<string, any>> {
     } else if (this.context.isEnding()) {
       throw new VFClientError('VFClient.sendText() was called but the conversation has ended');
     }
-    return this.setContext(await this.client.interact(makeRequestBody(this.context!, request, this.dataConfig), this.versionID));
+    this.setContext(await this.client.interact(makeRequestBody(this.context!, request, this.dataConfig), this.versionID));
+
+    if (this.dataConfig.traceProcessor) {
+      this.context.getResponse().forEach(this.dataConfig.traceProcessor);
+    }
+
+    return this.context;
   }
 
   private async getAppInitialState() {
@@ -86,10 +92,8 @@ class App<S extends Record<string, any> = Record<string, any>> {
     this.context = new Context({ request: null, state: _.cloneDeep(this.cachedInitState), trace: [] }, this.dataConfig);
   }
 
-  setContext(contextJSON: ResponseContext): Context<S> {
+  setContext(contextJSON: ResponseContext) {
     this.context = new Context(contextJSON, this.dataConfig);
-
-    return this.context;
   }
 
   getContext() {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,7 @@ export type DataConfig = {
   tts?: boolean;
   ssml?: boolean;
   includeTypes?: string[];
+  traceProcessor?: (trace: GeneralTrace) => any;
 };
 
 export type ResponseContext = {

--- a/tests/lib/fixtures.ts
+++ b/tests/lib/fixtures.ts
@@ -17,6 +17,14 @@ export const SPEAK_TRACE: SpeakTrace = {
   },
 };
 
+export const MAKE_SPEAK_TRACE = (payload: SpeakTrace['payload']): SpeakTrace => ({
+  type: TraceType.SPEAK,
+  payload: {
+    ...SPEAK_TRACE.payload,
+    ...payload
+  }
+});
+
 export const SPEAK_TRACE_AUDIO: SpeakTrace = {
   type: TraceType.SPEAK,
   payload: {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-5112**

### Brief description. What is this change?

Adds a `traceProcessor` option to the SDK configurations. The `traceProcessor` passed into the SDK will be automatically called onto `this.context.getResponse()` 

### Implementation details. How do you make this change?

Add a new config option that accepts a trace processor function.

If the function is passed in, then it is automatically applied on the traces when they are updated. 

We want to allow the client developer to do the following:
```ts
const traceProcessor = makeTraceProcessor({
  [TraceType.SPEAK]: (message) => console.log(message),
  [TraceType.DEBUG]: (message) => errorLogger.log(message),
});
const chatbot = new VFApp({
  versionID: MY_VERSION_ID,
  dataConfig: {
    tts: true,
    includeTypes: ['debug'],
    traceProcessor
  }
});

await chatbot.sendText(userResponse); 
// above call ^ automatically calls traceProcessor on the trace when it is
// returned from the backend.
```

### Setup information

None

### Deployment Notes

None

### Related PRs

None

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- [x] all the depedencies are upgraded