### PR TITLE
fix: broken typescript inferencing (CORE-5240)

### DIFF
--- a/lib/RuntimeClient/index.ts
+++ b/lib/RuntimeClient/index.ts
@@ -9,7 +9,7 @@ import { DataConfig, ResponseContext } from '@/lib/types';
 import { makeRequestBody, resetContext } from './utils';
 
 export class RuntimeClient<S extends Record<string, any> = Record<string, any>> {
-  private client: Client;
+  private client: Client<S>;
 
   private dataConfig: DataConfig;
 

--- a/lib/RuntimeClientFactory/index.ts
+++ b/lib/RuntimeClientFactory/index.ts
@@ -15,7 +15,7 @@ export type FactoryConfig<S extends State['variables']> = {
 };
 
 export class RuntimeClientFactory<S extends Record<string, any> = Record<string, any>> {
-  public client: Client;
+  public client: Client<S>;
 
   private dataConfig: DataConfig;
 
@@ -26,7 +26,7 @@ export class RuntimeClientFactory<S extends Record<string, any> = Record<string,
       validateVarMerge(variables);
     }
 
-    this.client = new Client<S>({ variables, endpoint, versionID });
+    this.client = new Client({ variables, endpoint, versionID });
     this.defaultState = { stack: [], storage: {}, variables: { ...variables } };
 
     this.dataConfig = {
@@ -38,7 +38,7 @@ export class RuntimeClientFactory<S extends Record<string, any> = Record<string,
   }
 
   createClient(state: State = this.defaultState) {
-    return new RuntimeClient(state, { client: this.client, dataConfig: this.dataConfig });
+    return new RuntimeClient<S>(state, { client: this.client, dataConfig: this.dataConfig });
   }
 }
 

--- a/tests/lib/RuntimeClientFactory/index.unit.ts
+++ b/tests/lib/RuntimeClientFactory/index.unit.ts
@@ -14,11 +14,11 @@ chai.use(chaiAsPromise);
 const CLIENT = { interact: 'foo' };
 const RUNTIME_CLIENT = { sendRequest: 'bar' };
 
-const createRuntimeClientFactory = (factoryConfig?: Partial<FactoryConfig<any>>) => {
+const createRuntimeClientFactory = <S>(factoryConfig?: Partial<FactoryConfig<any>>) => {
   const client = sinon.stub(Client, 'default').returns(CLIENT);
   const agent = sinon.stub(RuntimeClient, 'default').returns(RUNTIME_CLIENT);
 
-  const app = new RuntimeClientFactory({ versionID: VERSION_ID, ...factoryConfig });
+  const app = new RuntimeClientFactory<S>({ versionID: VERSION_ID, ...factoryConfig });
 
   return { client, agent, app };
 };


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-5240**

### Brief description. What is this change?

Fixing broken TypeScript inferencing for `.get()` and `.set()` methods in the `VariableManager`. This issue is that when specifying the variable schema `S` at `RuntimeClientFactory<S>(...)`, the type `S` is not being properly propagated down to the `Context` class

### Implementation details. How do you make this change?

Adding a `<S>` parameter to the call to the `RuntimeClient` constructor. 

All other changes are minor tweaks for more robust typing. 

### Setup information

None


### Deployment Notes

None

### Related PRs

None

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- ~~[ ] appropriate tests have been written~~ N/A
- [x] all the dependencies are upgraded