### PR TITLE
fix: fixing html-parse-stringify import (CORE-5197)

### DIFF
--- a/lib/Client/adapters/index.ts
+++ b/lib/Client/adapters/index.ts
@@ -1,6 +1,6 @@
 import { GeneralTrace, SpeakTrace, TraceType } from '@voiceflow/general-types';
 import { SpeakType } from '@voiceflow/general-types/build/nodes/speak';
-import { parse } from 'html-parse-stringify';
+import htmlParse from 'html-parse-stringify';
 
 import { ResponseContext } from '../../types';
 
@@ -14,7 +14,7 @@ export const parseAudioStepSrc = (trace: GeneralTrace): GeneralTrace => {
     return trace;
   }
 
-  const node = parse(trace.payload.message)[0];
+  const node = htmlParse.parse(trace.payload.message)[0];
 
   if (!node || node.name !== 'audio') {
     return {

--- a/lib/Client/index.ts
+++ b/lib/Client/index.ts
@@ -3,6 +3,7 @@ import axios, { AxiosInstance } from 'axios';
 import _cloneDeep from 'lodash/cloneDeep';
 
 import { RequestContext, ResponseContext } from '@/lib/types';
+
 import { adaptResponseContext } from './adapters';
 
 export type ClientConfig<S> = { variables?: Partial<S>; endpoint: string; versionID: string };

--- a/lib/Client/index.ts
+++ b/lib/Client/index.ts
@@ -3,6 +3,7 @@ import axios, { AxiosInstance } from 'axios';
 import _cloneDeep from 'lodash/cloneDeep';
 
 import { RequestContext, ResponseContext } from '@/lib/types';
+import { adaptResponseContext } from './adapters';
 
 export type ClientConfig<S> = { variables?: Partial<S>; endpoint: string; versionID: string };
 
@@ -37,7 +38,10 @@ class Client<S extends Record<string, any> = Record<string, any>> {
   }
 
   async interact(body: RequestContext): Promise<ResponseContext> {
-    return this.axios.post(`/interact/${this.versionID}`, body).then((response) => response.data);
+    return this.axios
+      .post(`/interact/${this.versionID}`, body)
+      .then((response) => response.data)
+      .then((context) => adaptResponseContext(context));
   }
 
   getVersionID() {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-5197**

### Brief description. What is this change?

Re-enables the fix for CORE-5197. This fixes a bug within the fix for CORE-5197, where a bad import caused `adaptResponseContext(...)` to break on React, but not Node.js for some reason.

### Implementation details. How do you make this change?

Using an import of the form `import { parse } from "html-parse-stringify"` is apparently wrong. Changed this to `import htmlParse from "html-parse-stringify"` and calling `htmlParse.parse(...)` instead of `parse(...)`.

### Setup information

None

### Deployment Notes

None

### Related PRs

| branch              | PR          |
| ------------------- | ----------- |
| Branch that introduced the fix for CORE-5197     | [link](https://github.com/voiceflow/runtime-client-js/pull/21) |
| Branch that removed the fix for CORE-5197 | [link](https://github.com/voiceflow/runtime-client-js/pull/23) |


### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- [x] all the dependencies are upgraded