### PR TITLE
refactor: removed APL from visual handler (CORE-5224)

### DIFF
--- a/lib/Utils/makeTraceProcessor/visual.ts
+++ b/lib/Utils/makeTraceProcessor/visual.ts
@@ -1,40 +1,12 @@
-import { VisualTrace } from '@voiceflow/general-types';
-import { VisualType } from '@voiceflow/general-types/build/nodes/visual';
-import _ from 'lodash';
+import { DeviceType, Dimensions, VisualTrace as CombinedVisualTrace } from '@voiceflow/general-types';
+import { CanvasVisibility, ImageStepData } from '@voiceflow/general-types/build/nodes/visual';
 
-import { VFClientError, VFTypeError } from '@/lib/Common';
+export type VisualTrace = CombinedVisualTrace & { payload: ImageStepData };
+export type VisualTraceHandler = (image: string | null, device: DeviceType | null, dimensions: Dimensions | null, visiblity: CanvasVisibility) => any;
 
-type APLPayload = Omit<VisualTrace['payload'] & { visualType: VisualType.APL }, 'visualType'>;
-type ImagePayload = Omit<VisualTrace['payload'] & { visualType: VisualType.IMAGE }, 'visualType'>;
-export type VisualTraceAPLHandler = (aplPayload: APLPayload) => any;
-export type VisualTraceImageHandler = (imgPayload: ImagePayload) => any;
-export type VisualTraceHandlerFunction = (payload: APLPayload | ImagePayload, visualType: VisualType) => any;
-export type VisualTraceHandlerMap = Partial<{
-  handleAPL: VisualTraceAPLHandler;
-  handleImage: VisualTraceImageHandler;
-}>;
-export type VisualTraceHandler = VisualTraceHandlerFunction | VisualTraceHandlerMap;
-
-export const invokeVisualHandler = (trace: VisualTrace, visualHandler: VisualTraceHandler) => {
+export const invokeVisualHandler = (trace: VisualTrace, handler: VisualTraceHandler) => {
   const {
-    payload: { visualType, ...rest },
+    payload: { image, device, dimensions, canvasVisibility },
   } = trace;
-
-  if (_.isFunction(visualHandler)) {
-    return visualHandler(rest, visualType);
-  }
-
-  if (visualType === VisualType.APL) {
-    if (!visualHandler.handleAPL) {
-      throw new VFClientError("missing handler for VisualTrace's apl subtype");
-    }
-    return visualHandler.handleAPL(rest as APLPayload);
-  }
-  if (visualType === VisualType.IMAGE) {
-    if (!visualHandler.handleImage) {
-      throw new VFClientError("missing handler for VisualTrace's image subtype");
-    }
-    return visualHandler.handleImage(rest as ImagePayload);
-  }
-  throw new VFTypeError("makeTraceProcessor's returned callback received an unknown VisualTrace subtype");
+  return handler(image, device, dimensions, canvasVisibility);
 };

--- a/tests/lib/Utils/makeTraceProcessor/fixtures.ts
+++ b/tests/lib/Utils/makeTraceProcessor/fixtures.ts
@@ -7,7 +7,7 @@ import { EndTraceHandler } from '@/lib/Utils/makeTraceProcessor/end';
 import { FlowTraceHandler } from '@/lib/Utils/makeTraceProcessor/flow';
 import { SpeakTraceHandlerFunction, SpeakTraceHandlerMap } from '@/lib/Utils/makeTraceProcessor/speak';
 import { StreamTraceHandler } from '@/lib/Utils/makeTraceProcessor/stream';
-import { VisualTraceHandlerFunction, VisualTraceHandlerMap } from '@/lib/Utils/makeTraceProcessor/visual';
+import { VisualTraceHandler } from '@/lib/Utils/makeTraceProcessor/visual';
 
 export const FAKE_SPEAK_TRACE = {
     type: TraceType.SPEAK,
@@ -52,18 +52,9 @@ export const speakHandlerMap: SpeakTraceHandlerMap = {
     }
 };
 
-export const visualHandlerMap: VisualTraceHandlerMap = {
-    handleAPL: (aplPayload) => {
-        return aplPayload;
-    },
-    handleImage: (imgPayload) => {
-        return imgPayload;
-    }
-}
-
 export const speakHandlerFunc: SpeakTraceHandlerFunction = (message, src, type) => [message, src, type];
 
-export const visualHandlerFunc: VisualTraceHandlerFunction = (payload, type) => [payload, type];
+export const visualHandlerFunc: VisualTraceHandler = (image, device, dimensions, visiblity) => [image, device, dimensions, visiblity];
 
 export const streamHandler: StreamTraceHandler = (src, action, token) => {
     return [src, action, token];

--- a/tests/lib/Utils/makeTraceProcessor/makeTraceProcess.unit.ts
+++ b/tests/lib/Utils/makeTraceProcessor/makeTraceProcess.unit.ts
@@ -1,4 +1,4 @@
-import { GeneralTrace, SpeakTrace, TraceType, VisualTrace } from '@voiceflow/general-types';
+import { GeneralTrace, SpeakTrace, TraceType } from '@voiceflow/general-types';
 import { invokeBlockHandler } from '@/lib/Utils/makeTraceProcessor/block';
 import { invokeChoiceHandler } from '@/lib/Utils/makeTraceProcessor/choice';
 import { invokeDebugHandler } from '@/lib/Utils/makeTraceProcessor/debug';
@@ -8,9 +8,9 @@ import { invokeSpeakHandler, SpeakTraceHandler, SpeakTraceHandlerMap } from '@/l
 import { invokeStreamHandler } from '@/lib/Utils/makeTraceProcessor/stream';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { BLOCK_TRACE, CHOICE_TRACE, DEBUG_TRACE, END_TRACE, FAKE_VISUAL_TRACE, FLOW_TRACE, SPEAK_TRACE, SPEAK_TRACE_AUDIO, STREAM_TRACE, VISUAL_TRACE_APL, VISUAL_TRACE_IMAGE } from '../../fixtures';
-import { blockHandler, choiceHandler, debugHandler, endHandler, FAKE_SPEAK_TRACE, flowHandler, RESULT, speakHandlerFunc, speakHandlerMap, streamHandler, TRACE_HANDLER_MAP, UNKNOWN_TRACE_TYPE, visualHandlerFunc, visualHandlerMap } from './fixtures';
-import { invokeVisualHandler, VisualTraceHandler } from '@/lib/Utils/makeTraceProcessor/visual';
+import { BLOCK_TRACE, CHOICE_TRACE, DEBUG_TRACE, END_TRACE, FLOW_TRACE, SPEAK_TRACE, SPEAK_TRACE_AUDIO, STREAM_TRACE, VISUAL_TRACE_IMAGE } from '../../fixtures';
+import { blockHandler, choiceHandler, debugHandler, endHandler, FAKE_SPEAK_TRACE, flowHandler, RESULT, speakHandlerFunc, speakHandlerMap, streamHandler, TRACE_HANDLER_MAP, UNKNOWN_TRACE_TYPE, visualHandlerFunc } from './fixtures';
+import { invokeVisualHandler } from '@/lib/Utils/makeTraceProcessor/visual';
 import { makeTraceProcessor } from '@/lib/Utils/makeTraceProcessor';
 
 describe('makeTraceProcessor', () => {
@@ -43,13 +43,24 @@ describe('makeTraceProcessor', () => {
         expect(result).to.eql(FLOW_TRACE.payload.diagramID);
     });
 
-    describe('invokeStreamHandler', () => {
+    it('invokeStreamHandler', () => {
         const result = invokeStreamHandler(STREAM_TRACE, streamHandler);
 
         expect(result).to.eql([
             STREAM_TRACE.payload.src,
             STREAM_TRACE.payload.action,
             STREAM_TRACE.payload.token,
+        ]);
+    });
+
+    it('invokeVisualHandler', () => {
+        const result = invokeVisualHandler(VISUAL_TRACE_IMAGE, visualHandlerFunc);
+
+        expect(result).to.eql([
+            VISUAL_TRACE_IMAGE.payload.image,
+            VISUAL_TRACE_IMAGE.payload.device,
+            VISUAL_TRACE_IMAGE.payload.dimensions,
+            VISUAL_TRACE_IMAGE.payload.canvasVisibility
         ]);
     });
 
@@ -103,55 +114,6 @@ describe('makeTraceProcessor', () => {
         it('unknown speak subtype', () => {
             const callback = () => invokeSpeakHandler(FAKE_SPEAK_TRACE as SpeakTrace, speakHandlerMap)
             expect(callback).to.throw("VFError: makeTraceProcessor's returned callback received an unknown SpeakTrace subtype");
-        });
-    });
-
-    describe('invokeVisualHandler', () => {
-        it('function handler', () => {
-            const result = invokeVisualHandler(VISUAL_TRACE_APL, visualHandlerFunc);
-
-            const { visualType, ...rest } = VISUAL_TRACE_APL.payload;
-            expect(result).to.eql([
-                rest,
-                visualType
-            ]);
-        });
-
-        it('invokes apl handler', () => {
-            const handler: VisualTraceHandler = {
-                handleAPL: visualHandlerMap.handleAPL
-            };
-
-            const result = invokeVisualHandler(VISUAL_TRACE_APL, handler);
-
-            const { visualType, ...restPayload } = VISUAL_TRACE_APL.payload;
-            expect(result).to.eql(restPayload);
-        });
-
-        it('invokes image handler', () => {
-            const handler: VisualTraceHandler = {
-                handleImage: visualHandlerMap.handleImage
-            };
-
-            const result = invokeVisualHandler(VISUAL_TRACE_IMAGE, handler);
-
-            const { visualType, ...restPayload } = VISUAL_TRACE_IMAGE.payload;
-            expect(result).to.eql(restPayload);
-        });
-
-        it('unimplemented apl handler', () => {
-            const callback = () => invokeVisualHandler(VISUAL_TRACE_APL, {});
-            expect(callback).to.throw("VFError: missing handler for VisualTrace's apl subtype");
-        });
-
-        it('unimplemented image handler', () => {
-            const callback = () => invokeVisualHandler(VISUAL_TRACE_IMAGE, {});
-            expect(callback).to.throw("VFError: missing handler for VisualTrace's image subtype");
-        });
-
-        it('invokeVisualHandler, unknown visual subtype', () => {
-            const callback = () => invokeVisualHandler(FAKE_VISUAL_TRACE as VisualTrace, visualHandlerMap)
-            expect(callback).to.throw("VFError: makeTraceProcessor's returned callback received an unknown VisualTrace subtype");
         });
     });
 

--- a/tests/lib/fixtures.ts
+++ b/tests/lib/fixtures.ts
@@ -12,7 +12,7 @@ import {
 } from '@voiceflow/general-types';
 import { SpeakType } from '@voiceflow/general-types/build/nodes/speak';
 import { TraceStreamAction } from '@voiceflow/general-types/build/nodes/stream';
-import { APLType, CanvasVisibility, VisualType } from '@voiceflow/general-types/build/nodes/visual';
+import { CanvasVisibility, VisualType } from '@voiceflow/general-types/build/nodes/visual';
 
 export type VFAppVariablesSchema = {
   age: number | 0;
@@ -96,14 +96,6 @@ export const DEBUG_TRACE: DebugTrace = {
 
 export const END_TRACE: ExitTrace = {
   type: TraceType.END,
-};
-
-export const VISUAL_TRACE_APL: VisualTrace & { payload: { visualType: VisualType.APL } } = {
-  type: TraceType.VISUAL,
-  payload: {
-    visualType: VisualType.APL,
-    aplType: APLType.JSON,
-  },
 };
 
 export const VISUAL_TRACE_IMAGE: VisualTrace & { payload: { visualType: VisualType.IMAGE } } = {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-5224**

### Brief description. What is this change?

Removing reference to APL from the `runtime-client-js` visual handler code. This APL subtype of the `VisualTrace` isn't actually being generated by the `general-runtime` or `general-service`

### Implementation details. How do you make this change?

Simplifying the `invokeVisualHandler` implementation for `makeTraceProcessor()`.

### Setup information

None

### Deployment Notes

None

### Related PRs

None

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- [x] all the dependencies are upgraded