### PR TITLE
fix: add index to handler (CORE-000)

### DIFF
--- a/lib/Events/index.ts
+++ b/lib/Events/index.ts
@@ -4,9 +4,9 @@ import { GeneralTrace, TraceMap, TraceType } from '@/lib/types';
 
 import Context from '../Context';
 
-export type TraceEventHandler<T extends TraceType, V extends Record<string, any>> = (trace: TraceMap[T], context: Context<V>) => void;
+export type TraceEventHandler<T extends TraceType, V extends Record<string, any>> = (trace: TraceMap[T], context: Context<V>, index: number) => void;
 
-export type GeneralTraceEventHandler<V extends Record<string, any>> = (trace: GeneralTrace, context: Context<V>) => void;
+export type GeneralTraceEventHandler<V extends Record<string, any>> = (trace: GeneralTrace, context: Context<V>, index: number) => void;
 
 type _Map<T extends Record<string, any>, K extends TraceType = TraceType> = Map<K, Array<TraceEventHandler<K, T>>>;
 
@@ -43,12 +43,12 @@ export class EventManager<V extends Record<string, any>> {
   }
 
   async handle<T extends TraceType>(trace: TraceMap[T], context: Context<V>) {
-    await Bluebird.each(this.specHandlers.get(trace.type)!, async (handler: TraceEventHandler<T, V>) => {
-      await handler(trace, context);
+    await Bluebird.each(this.specHandlers.get(trace.type)!, async (handler: TraceEventHandler<T, V>, index) => {
+      await handler(trace, context, index);
     });
 
-    await Bluebird.each(this.genHandlers, async (handler: GeneralTraceEventHandler<V>) => {
-      await handler(trace, context);
+    await Bluebird.each(this.genHandlers, async (handler: GeneralTraceEventHandler<V>, index) => {
+      await handler(trace, context, index);
     });
   }
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-000**

### Brief description. What is this change?

Get the index of the trace as well in the event handler, so it is possible to know exactly which trace you are handling.
This is for extreme edge cases: in messenger the chips HAVE to be sent with the last speak.

I do something like this:
<img width="520" alt="Screen Shot 2021-03-01 at 11 36 13 AM" src="https://user-images.githubusercontent.com/5643574/109528129-5e380980-7a82-11eb-8b45-ae346d643662.png">

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to undertand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
- [ ] updated the documentation
