### PR TITLE
fix: default path select (VF-876)

### DIFF
--- a/lib/Events/index.ts
+++ b/lib/Events/index.ts
@@ -37,7 +37,7 @@ export class EventManager<V extends Record<string, any>> {
 
   constructor() {
     this.specHandlers = new Map();
-    const traceTypeVals = Object.keys(TraceType).map((type) => type.toLowerCase()) as TraceType[];
+    const traceTypeVals = Object.values(TraceType);
     traceTypeVals.forEach((traceType) => this.specHandlers.set(traceType, []));
 
     this.genHandlers = [];

--- a/lib/RuntimeClient/index.ts
+++ b/lib/RuntimeClient/index.ts
@@ -116,7 +116,7 @@ export class RuntimeClient<V extends Record<string, any> = Record<string, any>> 
     const lastTrace = traces[traces.length - 1];
     if (!is_V1Trace(lastTrace)) return this.context;
 
-    const path = (await this.responseHandler(lastTrace, this.context)) || lastTrace.defaultPath;
+    const path = (await this.responseHandler(lastTrace, this.context)) ?? lastTrace.defaultPath;
     if (typeof path !== 'number') return this.context;
 
     const type = (lastTrace.paths || [])[path]?.event?.type;

--- a/tests/lib/RuntimeClient/index.unit.ts
+++ b/tests/lib/RuntimeClient/index.unit.ts
@@ -453,11 +453,11 @@ describe('RuntimeClient', () => {
     it('works', async () => {
       const output = { foo: 'bar' };
       const { agent } = createRuntimeClient();
-      const sideEffect = sinon.stub().resolves(1);
+      const sideEffect = sinon.stub().resolves(0);
       agent.onResponse(sideEffect);
       const sendRequestStub = sinon.stub().resolves(output);
       _.set(agent, 'sendRequest', sendRequestStub);
-      const context = { trace: [{}, { payload: {}, paths: [{}, { event: { type: 'trace' } }] }] };
+      const context = { trace: [{}, { payload: {}, paths: [{ event: { type: 'trace' } }, {}] }] };
       agent.setContext(context as any);
 
       expect((await agent.buildResponse()) as any).to.eql(output);


### PR DESCRIPTION
**Fixes or implements VF-876**

Related to #58.

### Brief description. What is this change?

Using the `||` operator would use the default branch when the return value was `0` (`0` is falsy).
Using the `??` operator will only use the default branch when the return value is nullish.

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- [ ] all the dependencies are upgraded
